### PR TITLE
Draw background image instead of color when set

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Choose from the broad spectre of styleable elements:
  * `ppvStrokeWidth` - The width of stroke around the view.
  * `ppvStrokeColor` - The color of stroke around the view.
  * `ppvBackgroundColor` - The color of the views background.
+ * `ppvBackgroundImage` - The background image for the view (takes precedence over the background color).
  * `ppvProgressColor` - The color view of the views progress.
  * `ppvInverted` - Inverts the drawing of progress (fill radial only).
  * `ppvCounterclockwise` - Draws the progress counterclockwise (fill radial only).

--- a/library/src/main/java/com/filippudak/ProgressPieView/ProgressPieView.java
+++ b/library/src/main/java/com/filippudak/ProgressPieView/ProgressPieView.java
@@ -62,7 +62,9 @@ public class ProgressPieView extends View {
     private String mTypeface;
     private boolean mShowImage = true;
     private Drawable mImage;
+    private Drawable mBackgroundImage;
     private Rect mImageRect;
+    private Rect mBackgroundImageRect;
     private Paint mStrokePaint;
     private Paint mTextPaint;
     private Paint mProgressPaint;
@@ -110,6 +112,7 @@ public class ProgressPieView extends View {
         mShowStroke = a.getBoolean(R.styleable.ProgressPieView_ppvShowStroke, mShowStroke);
         mShowText = a.getBoolean(R.styleable.ProgressPieView_ppvShowText, mShowText);
         mImage = a.getDrawable(R.styleable.ProgressPieView_ppvImage);
+        mBackgroundImage = a.getDrawable(R.styleable.ProgressPieView_ppvBackgroundImage);
 
         int backgroundColor = res.getColor(R.color.default_background_color);
         backgroundColor = a.getColor(R.styleable.ProgressPieView_ppvBackgroundColor, backgroundColor);
@@ -144,6 +147,7 @@ public class ProgressPieView extends View {
 
         mInnerRectF = new RectF();
         mImageRect = new Rect();
+        mBackgroundImageRect = new Rect();
     }
 
     @Override
@@ -169,7 +173,15 @@ public class ProgressPieView extends View {
         float centerX = mInnerRectF.centerX();
         float centerY = mInnerRectF.centerY();
 
-        canvas.drawArc(mInnerRectF, 0, 360, true, mBackgroundPaint);
+        if (mBackgroundImage != null) {
+            int drawableSize = mBackgroundImage.getIntrinsicWidth();
+            mBackgroundImageRect.set(0, 0, drawableSize, drawableSize);
+            mBackgroundImageRect.offset((getWidth() - drawableSize) / 2, (getHeight() - drawableSize) / 2);
+            mBackgroundImage.setBounds(mBackgroundImageRect);
+            mBackgroundImage.draw(canvas);
+        } else {
+            canvas.drawArc(mInnerRectF, 0, 360, true, mBackgroundPaint);
+        }
 
         switch (mProgressFillType) {
             case FILL_TYPE_RADIAL:
@@ -523,6 +535,33 @@ public class ProgressPieView extends View {
     public void setShowStroke(boolean showStroke) {
         mShowStroke = showStroke;
         invalidate();
+    }
+
+    /**
+     * Gets the background drawable of the view.
+     */
+    public Drawable getBackgroundImageDrawable() {
+        return mBackgroundImage;
+    }
+
+    /**
+     * Sets the background drawable of the view.
+     * @param backgroundImage background drawable of the view
+     */
+    public void setBackgroundImageDrawable(Drawable backgroundImage) {
+        mBackgroundImage = backgroundImage;
+        invalidate();
+    }
+
+    /**
+     * Sets the background drawable of the view.
+     * @param resId resource id of the view's background drawable
+     */
+    public void setBackgroundImageResource(int resId) {
+        if (null != getResources()) {
+            mBackgroundImage = getResources().getDrawable(resId);
+            invalidate();
+        }
     }
 
     /**

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -11,6 +11,7 @@
         <attr name="ppvCounterclockwise" format="boolean"/>
         <attr name="ppvStrokeWidth" format="dimension"/>
         <attr name="ppvBackgroundColor" format="reference|color"/>
+        <attr name="ppvBackgroundImage" format="reference"/>
         <attr name="ppvProgressColor" format="reference|color"/>
         <attr name="ppvStrokeColor" format="reference|color"/>
         <attr name="ppvShowStroke" format="boolean"/>


### PR DESCRIPTION
This pull request allows drawing an image in the background instead of just specifying only a background color. A background image takes precedence over a background color.

The background image is not rounded by this pull request, but you may set an [RoundedDrawable](https://github.com/vinc3m1/RoundedImageView/blob/master/roundedimageview/src/main/java/com/makeramen/RoundedDrawable.java) found in the [RoundedImageView library](https://github.com/vinc3m1/RoundedImageView/). 
